### PR TITLE
Exclude xarray 0.14.1 (last release)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: xarray-simlab-{{ version }}.tar.gz
   url: https://github.com/benbovy/xarray-simlab/archive/{{ version }}.tar.gz
-  sha256: 27d8775783e47fb4c419e7270da5aea4a7bbaf5dd741c7f58d4e2469b9937627
+  sha256: b94454eb963c70f5767de93ff73d2c912924d84d5851ef1a94953db9f9df9257
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 27d8775783e47fb4c419e7270da5aea4a7bbaf5dd741c7f58d4e2469b9937627
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
@@ -22,7 +22,7 @@ requirements:
     - python >=3
     - attrs >=18.1.0
     - numpy
-    - xarray >=0.10.0
+    - xarray >=0.10.0,<0.14.1
 
 test:
   imports:


### PR DESCRIPTION
xarray-simlab is broken due to a bug introduced in the latest release of xarray.

This is fixed in xarray-simlab master branch so it should be removed for the
next release.
